### PR TITLE
Upgrading to new requireJS version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>d3js</artifactId>
-            <version>2.10.3</version>
+            <version>3.4.4-1</version>
         </dependency>
     </dependencies>
     

--- a/src/main/resources/webjars-requirejs.js
+++ b/src/main/resources/webjars-requirejs.js
@@ -2,7 +2,11 @@
 
 // Ensure any request for this webjar brings in jQuery.
 requirejs.config({
-    shim: {
-        'nv.d3': [ 'webjars!d3.js' ]
+    paths: { "nvd3": webjars.path("nvd3", "nv.d3") },
+    shim: { 
+        'nvd3':  { 
+            'deps' : [ 'd3js'],
+            'exports': 'nv'
+        } 
     }
 });


### PR DESCRIPTION
updated d3 dependency for correct requireJS handling. 
Nvd3 depends current on `3.1.1`.
